### PR TITLE
avoid undefined error in batch operation

### DIFF
--- a/lib/requests/helpers/parseResponse.js
+++ b/lib/requests/helpers/parseResponse.js
@@ -148,7 +148,7 @@ function parseBatchResponse(response, parseParams, requestNumber) {
                     result.push(isNaN(plainContent) ? plainContent : parseInt(plainContent));
                 }
                 else
-                    if (parseParams.length && parseParams[requestNumber].hasOwnProperty('valueIfEmpty')) {
+                    if (parseParams.length && parseParams[requestNumber] && parseParams[requestNumber].hasOwnProperty('valueIfEmpty')) {
                         result.push(parseParams[requestNumber].valueIfEmpty);
                     }
                     else {


### PR DESCRIPTION
When using ```dynamicsWebApi.executeBatch()``` will encounter ```parseParams[requestNumber]``` is undefined error and therefore leads to crashes.